### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -752,7 +752,7 @@ A broader map of the agent design space surrounding Claude Code. The [Cross-Syst
 </details>
 
 ---
-[![Star History Chart](https://api.star-history.com/svg?repos=VILA-Lab/Dive-into-Claude-Code&type=Date)](https://www.star-history.com/#VILA-Lab/Dive-into-Claude-Code&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=VILA-Lab/Dive-into-Claude-Code&type=Date)](https://star-history.dera.page/#VILA-Lab/Dive-into-Claude-Code&Date)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -752,7 +752,13 @@ A broader map of the agent design space surrounding Claude Code. The [Cross-Syst
 </details>
 
 ---
-[![Star History Chart](https://star-history.dera.page/svg?repos=VILA-Lab/Dive-into-Claude-Code&type=Date)](https://star-history.dera.page/#VILA-Lab/Dive-into-Claude-Code&Date)
+<a href="https://star-history.dera.page/#VILA-Lab/Dive-into-Claude-Code">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=VILA-Lab/Dive-into-Claude-Code&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=VILA-Lab/Dive-into-Claude-Code&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=VILA-Lab/Dive-into-Claude-Code&type=Date" />
+  </picture>
+</a>
 
 ## Contributing
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -753,7 +753,7 @@ Claude Code 回答了每个生产级编码智能体都必须面对的**四个设
 
 ---
 
-[![Star History Chart](https://api.star-history.com/svg?repos=VILA-Lab/Dive-into-Claude-Code&type=Date)](https://www.star-history.com/#VILA-Lab/Dive-into-Claude-Code&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=VILA-Lab/Dive-into-Claude-Code&type=Date)](https://star-history.dera.page/#VILA-Lab/Dive-into-Claude-Code&Date)
 
 ## 参与贡献
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -753,7 +753,13 @@ Claude Code 回答了每个生产级编码智能体都必须面对的**四个设
 
 ---
 
-[![Star History Chart](https://star-history.dera.page/svg?repos=VILA-Lab/Dive-into-Claude-Code&type=Date)](https://star-history.dera.page/#VILA-Lab/Dive-into-Claude-Code&Date)
+<a href="https://star-history.dera.page/#VILA-Lab/Dive-into-Claude-Code">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=VILA-Lab/Dive-into-Claude-Code&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=VILA-Lab/Dive-into-Claude-Code&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=VILA-Lab/Dive-into-Claude-Code&type=Date" />
+  </picture>
+</a>
 
 ## 参与贡献
 


### PR DESCRIPTION
The star history chart on the README is currently broken due to GitHub stargazer API restrictions. This switches it to a working source so the chart renders correctly again for both the main and Chinese READMEs.